### PR TITLE
Fixed -Wcast-qual warning from GCC

### DIFF
--- a/sha256.cpp
+++ b/sha256.cpp
@@ -107,7 +107,7 @@ void SHA256::processBlock(const void* data)
   uint32_t h = m_hash[7];
 
   // data represented as 16x 32-bit words
-  const uint32_t* input = (uint32_t*) data;
+  const uint32_t* input = (const uint32_t*) data;
   // convert to big endian
   uint32_t words[64];
   int i;


### PR DESCRIPTION
This fixes following warning from GCC

```bash
../hash-library/sha256.cpp: In member function ‘void SHA256::processBlock(const void*)’:
../hash-library/sha256.cpp:110:27: warning: cast from type ‘const void*’ to type ‘uint32_t*’ {aka ‘unsigned int*’} casts away qualifiers [-Wcast-qual]
  110 |   const uint32_t* input = (uint32_t*) data;
      |                           ^~~~~~~~~~~~~~~~
```