### PR TITLE
Fixed -Wshadow warning from GCC

### DIFF
--- a/keccak.cpp
+++ b/keccak.cpp
@@ -152,14 +152,14 @@ void Keccak::processBlock(const void* data)
     for (unsigned int j = 0; j < StateSize; j += 5)
     {
       // temporaries
-      uint64_t one = m_hash[j];
-      uint64_t two = m_hash[j + 1];
+      uint64_t One = m_hash[j];
+      uint64_t Two = m_hash[j + 1];
 
-      m_hash[j]     ^= m_hash[j + 2] & ~two;
+      m_hash[j]     ^= m_hash[j + 2] & ~Two;
       m_hash[j + 1] ^= m_hash[j + 3] & ~m_hash[j + 2];
       m_hash[j + 2] ^= m_hash[j + 4] & ~m_hash[j + 3];
-      m_hash[j + 3] ^=      one      & ~m_hash[j + 4];
-      m_hash[j + 4] ^=      two      & ~one;
+      m_hash[j + 3] ^=      One      & ~m_hash[j + 4];
+      m_hash[j + 4] ^=      Two      & ~One;
     }
 
     // Iota


### PR DESCRIPTION
This commit fixes

```bash
keccak.cpp: In member function ‘void Keccak::processBlock(const void*)’:
keccak.cpp:155:16: warning: declaration of ‘one’ shadows a previous local [-Wshadow]
  155 |       uint64_t one = m_hash[j];
      |                ^~~
keccak.cpp:122:14: note: shadowed declaration is here
  122 |     uint64_t one;
      |              ^~~
```