### PR TITLE
fix ub in md5.cpp

### DIFF
--- a/md5.cpp
+++ b/md5.cpp
@@ -296,7 +296,7 @@ void MD5::processBuffer()
   if (paddedLength < BlockSize)
     addLength = m_buffer + paddedLength;
   else
-    addLength = extra + paddedLength - BlockSize;
+    addLength = extra + (paddedLength - BlockSize);
 
   // must be little endian
   *addLength++ = msgBits & 0xFF; msgBits >>= 8;


### PR DESCRIPTION
Have the following sanitizer output:

```
md5.cpp:299:23: runtime error: index 120 out of bounds for type 'unsigned char [64]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior md5.cpp:299:23 in
```

This commit fixes that.