### PR TITLE
Fix misleading msvc macro and unreachable return in swap function

### DIFF
--- a/crc32.cpp
+++ b/crc32.cpp
@@ -322,15 +322,14 @@ namespace
   {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap32(x);
-#endif
-#ifdef MSC_VER
+#elif defined(_MSC_VER)
     return _byteswap_ulong(x);
-#endif
-
+#else
     return (x >> 24) |
           ((x >>  8) & 0x0000FF00) |
           ((x <<  8) & 0x00FF0000) |
            (x << 24);
+#endif
   }
 }
 

--- a/keccak.cpp
+++ b/keccak.cpp
@@ -59,11 +59,9 @@ namespace
   {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap64(x);
-#endif
-#ifdef _MSC_VER
+#elif defined(_MSC_VER)
     return _byteswap_uint64(x);
-#endif
-
+#else
     return  (x >> 56) |
            ((x >> 40) & 0x000000000000FF00ULL) |
            ((x >> 24) & 0x0000000000FF0000ULL) |
@@ -72,6 +70,7 @@ namespace
            ((x << 24) & 0x0000FF0000000000ULL) |
            ((x << 40) & 0x00FF000000000000ULL) |
             (x << 56);
+#endif
   }
 
 

--- a/md5.cpp
+++ b/md5.cpp
@@ -65,15 +65,14 @@ namespace
   {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap32(x);
-#endif
-#ifdef MSC_VER
+#elif defined(_MSC_VER)
     return _byteswap_ulong(x);
-#endif
-
+#else
     return (x >> 24) |
           ((x >>  8) & 0x0000FF00) |
           ((x <<  8) & 0x00FF0000) |
            (x << 24);
+#endif
   }
 #endif
 }

--- a/sha1.cpp
+++ b/sha1.cpp
@@ -61,15 +61,14 @@ namespace
   {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap32(x);
-#endif
-#ifdef MSC_VER
+#elif defined(_MSC_VER)
     return _byteswap_ulong(x);
-#endif
-
+#else
     return (x >> 24) |
           ((x >>  8) & 0x0000FF00) |
           ((x <<  8) & 0x00FF0000) |
            (x << 24);
+#endif
   }
 }
 

--- a/sha256.cpp
+++ b/sha256.cpp
@@ -65,15 +65,14 @@ namespace
   {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap32(x);
-#endif
-#ifdef MSC_VER
+#elif defined(_MSC_VER)
     return _byteswap_ulong(x);
-#endif
-
+#else
     return (x >> 24) |
           ((x >>  8) & 0x0000FF00) |
           ((x <<  8) & 0x00FF0000) |
            (x << 24);
+#endif
   }
 
   // mix functions for processBlock()

--- a/sha3.cpp
+++ b/sha3.cpp
@@ -61,11 +61,9 @@ namespace
   {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap64(x);
-#endif
-#ifdef _MSC_VER
+#elif defined(_MSC_VER)
     return _byteswap_uint64(x);
-#endif
-
+#else
     return  (x >> 56) |
            ((x >> 40) & 0x000000000000FF00ULL) |
            ((x >> 24) & 0x0000000000FF0000ULL) |
@@ -74,8 +72,8 @@ namespace
            ((x << 24) & 0x0000FF0000000000ULL) |
            ((x << 40) & 0x00FF000000000000ULL) |
             (x << 56);
+#endif
   }
-
 
   /// return x % 5 for 0 <= x <= 9
   unsigned int mod5(unsigned int x)


### PR DESCRIPTION
Hello,
This PR addresses the following issues.

1. In several files, the `swap(...)` function has used `MSC_VER` instead of `_MSC_VER` which will lead them to fall back to the manual implementation of the byte `swap(...)` function. 
2. If the compiler has built-in support for byte swapping then it generally will create a warning about the use of two returns, where the last one is unreachable since the built-in has already been provided. Using `#else` for the manual implementation (e.g. If the compiler doesn't have a built-in byte swap function), then the warning can be avoided.